### PR TITLE
Use itamae module instead of 'itamae/runner'

### DIFF
--- a/lib/tenma/ichiba/instance.rb
+++ b/lib/tenma/ichiba/instance.rb
@@ -1,4 +1,4 @@
-require 'itamae/runner'
+require 'itamae'
 require 'tenma/runnable'
 
 module Tenma

--- a/lib/tenma/version.rb
+++ b/lib/tenma/version.rb
@@ -1,3 +1,3 @@
 module Tenma
-  VERSION = "0.9.2"
+  VERSION = "0.9.3"
 end


### PR DESCRIPTION
@hisaichi5518 
Itamae v1.10.4 にアップデートしたら ichiba メソッドによるインスタンスのプロビジョニングが動かなくなったので直しに来ました

```
bundler: failed to load command: tenma (/repo/vendor/bundle/ruby/2.6.0/bin/tenma)
NoMethodError: undefined method `logger' for Itamae:Module
  /repo/vendor/bundle/ruby/2.6.0/gems/itamae-1.10.4/lib/itamae/runner.rb:8:in `run'
  /repo/vendor/bundle/ruby/2.6.0/gems/tenma-0.9.2/lib/tenma/ichiba/instance.rb:42:in `provision'
  /repo/vendor/bundle/ruby/2.6.0/gems/tenma-0.9.2/lib/tenma/ichiba/command.rb:22:in `execute'
  /repo/vendor/bundle/ruby/2.6.0/gems/tenma-0.9.2/lib/tenma/cli.rb:33:in `ichiba'
  /repo/vendor/bundle/ruby/2.6.0/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'
  /repo/vendor/bundle/ruby/2.6.0/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'
  /repo/vendor/bundle/ruby/2.6.0/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'
  /repo/vendor/bundle/ruby/2.6.0/gems/thor-0.20.3/lib/thor/base.rb:466:in `start'
  /repo/vendor/bundle/ruby/2.6.0/gems/tenma-0.9.2/exe/tenma:5:in `<top (required)>'
  /repo/vendor/bundle/ruby/2.6.0/bin/tenma:23:in `load'
  /repo/vendor/bundle/ruby/2.6.0/bin/tenma:23:in `<top (required)>'
```

## 参考

https://github.com/itamae-kitchen/itamae/compare/v1.10.3...v1.10.4

今までは `require 'itamae'` が各モジュール内にあったため名前解決できていたようでした。

本家をいじるか迷ったんですが itamae コマンドを使う前提 = `require 'itamae'` 作られているのと、`require 'itamae'` しとけば今後アップデートがあっても対応できそうだなということでこのようにしとります。