### PR TITLE
Enable to specify java sdk version

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ android_sdk:
         - extra-android-m2repository
         - extra-google-m2repository
         - extra-google-google_play_services
+
+# Specify your java sdk version. Default: 8
+java_version: 11
 ```
 
 #### 4. :runner: Run command

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ android_sdk:
         - extra-google-m2repository
         - extra-google-google_play_services
 
-# Specify your java sdk version. Default: 8
+# Specify java sdk version if needed. Default: 8
 java_version: 11
 ```
 

--- a/lib/tenma/ichiba/itamae/cookbooks/android-sdk/dependency.rb
+++ b/lib/tenma/ichiba/itamae/cookbooks/android-sdk/dependency.rb
@@ -5,5 +5,6 @@ if node[:kernel][:machine] == 'x86_64'
   end
 end
 
-# Install Java8
-package "openjdk-8-jdk-headless"
+# Install Java
+java_version = node[:java_version] || 8
+package "openjdk-#{java_version}-jdk-headless"


### PR DESCRIPTION
## これは

temba ichiba でのリモートインスタンスセットアップ時に、Java 11 をプロジェクトで必要としている場合でも指定できるようにしました。挙動が変わらないようにデフォルトは Java 8 が入るようにしてます

AGP 7.0 では必須になります
https://developers-jp.googleblog.com/2020/12/announcing-android-gradle-plugin.html